### PR TITLE
Spec 1157 api client setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,107 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# editor
+*.sw?

--- a/api-tools/requirements.txt
+++ b/api-tools/requirements.txt
@@ -1,2 +1,0 @@
-requests==2.20.0
-unicodecsv==0.14.1

--- a/api-tools/setup.py
+++ b/api-tools/setup.py
@@ -1,11 +1,46 @@
-#!/usr/bin/env python
+'Install trident_client module'
 
-from distutils.core import setup
+from os import path
+from codecs import open
+from setuptools import setup
 
-setup(name='trident_client',
-    version='1.0',
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='trident_client',
+    version='1.2',
     description='JASK Trident API Client',
+    long_description=long_description,
+    url='https://github.com/jasklabs/jask-api',
+    author='JASK Labs',
     author_email='support@jask.io',
-    url='https://jask.io',
+    license='',
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        #'Development Status :: 1 - Planning',
+        #'Development Status :: 2 - Pre-Alpha',
+        #'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
+        #'Development Status :: 5 - Production/Stable',
+        #'Development Status :: 6 - Mature',
+        #'Development Status :: 7 - Inactive',
+        'Environment :: Console',
+        'Intended Audience :: Information Technology',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: POSIX',
+        'Programming Language :: Python :: 3',
+        'Topic :: Security',
+    ],
     packages=['trident_client'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'requests==2.20.0',
+        'unicodecsv==0.14.1',
+    ],
 )

--- a/api-tools/trident_client/__init__.py
+++ b/api-tools/trident_client/__init__.py
@@ -1,3 +1,3 @@
-from asset_api import get_asset_detail, update_metadata, delete_metadata
-from search_api import SEARCH_ALL, SEARCH_ASSETS, SEARCH_ALERTS, SEARCH_SIGNALS, search, get_details
-from status_api import list_sensors, list_users
+from .asset_api import get_asset_detail, update_metadata, delete_metadata
+from .search_api import SEARCH_ALL, SEARCH_ASSETS, SEARCH_ALERTS, SEARCH_SIGNALS, search, get_details
+from .status_api import list_sensors, list_users

--- a/api-tools/trident_client/asset_api.py
+++ b/api-tools/trident_client/asset_api.py
@@ -1,5 +1,5 @@
 import logging, requests
-from utils import validate_basic_params
+from .utils import validate_basic_params
 
 log = logging.getLogger()
 

--- a/api-tools/trident_client/configuration_api.py
+++ b/api-tools/trident_client/configuration_api.py
@@ -1,7 +1,10 @@
-from utils import validate_basic_params
 import logging
+
 import requests
 import unicodecsv as csv
+
+from .utils import validate_basic_params
+
 
 log = logging.getLogger()
 

--- a/api-tools/trident_client/intel_api.py
+++ b/api-tools/trident_client/intel_api.py
@@ -1,9 +1,11 @@
-import logging
 import sys
+import logging
+
 import requests
 import unicodecsv as csv
 
-from utils import validate_basic_params, is_int_string
+from .utils import validate_basic_params, is_int_string
+
 
 log = logging.getLogger()
 

--- a/api-tools/trident_client/search_api.py
+++ b/api-tools/trident_client/search_api.py
@@ -1,5 +1,9 @@
-import logging, requests
-from utils import validate_basic_params
+import logging
+
+import requests
+
+from .utils import validate_basic_params
+
 
 log = logging.getLogger()
 

--- a/api-tools/trident_client/status_api.py
+++ b/api-tools/trident_client/status_api.py
@@ -1,4 +1,4 @@
-from utils import get_simple_list, validate_basic_params
+from .utils import get_simple_list, validate_basic_params
 
 """
 Get a list of the sensors associated with this cluster.


### PR DESCRIPTION
Hoping to slightly modernize and improve the python client API code incrementally here just to fix up that some of our scripts don't seem to run at all in the current incarnation. See commit logs for details. Tested in a Python 3 virtualenv with this setup and was able to properly update the netblocks in a customer after streamlining this module. Prior it seemed to be a dance to get in the proper directory to do some imports and even then I'm not convinced it would have been able to work. This should hopefully better fit current patterns in e.g. https://python-packaging.readthedocs.io/en/latest/. 

One thing I'm hoping you can verify @josh-williams is that we're OK dropping the requirements.txt since those are now present in setup.py (`install_requires`).

@spdietz if this is clear I'd like to do another test and then update the user-facing doc in https://jasklabs.atlassian.net/wiki/spaces/CS1/pages/695730197/Importing+Network+Blocks+using+the+JASK+REST+API. 